### PR TITLE
Disable Chroma Interpolation menu entry if Digital Color Format is YC422

### DIFF
--- a/Firmware/README.md
+++ b/Firmware/README.md
@@ -385,9 +385,10 @@ with displays. On the other hand, changing some settings here may allow you to
 use a display that refuses to cooperate with the default settings, although
 possibly at reduced output quality.
 
-"Chroma Interpolation" is on by default. If you turn it off, the output image
-will have a slight color shift as well as stronger staircasing/pixelation
-on color transitions.
+"Chroma Interpolation" is on by default, and is only available when the
+"Digital color format" option is set to anything other than "YC422". If you turn
+it off, the output image will have a slight color shift as well as stronger
+staircasing/pixelation on color transitions.
 
 "Fix resolution" is on by default. When it is on, GCVideo applies black borders
 to the console's image to extend it to a standard-conforming resolution. Many

--- a/Firmware/screen_advanced.c
+++ b/Firmware/screen_advanced.c
@@ -109,6 +109,13 @@ static void advanced_draw(menu_t *menu) {
   } else {
     advanced_items[MENUITEM_COLORMODE].flags = MENU_FLAG_DISABLED;
   }
+
+  if ((video_settings_global & VIDEOIF_SET_COLORMODE_MASK) ==
+        VIDEOIF_SET_COLORMODE_Y422) {
+    advanced_items[MENUITEM_CHROMAINTERPOL].flags = MENU_FLAG_DISABLED;
+  } else {
+    advanced_items[MENUITEM_CHROMAINTERPOL].flags = 0;
+  }
 }
 
 void screen_advanced(void) {


### PR DESCRIPTION
Proposal:

For YCbCr 4:2:2 output, chroma interpolation has no effect, since gcvideo only
has access to YCbCr 4:2:2 input anyway. This intentionally doesn't change the
option's effective value; it is meant as way of signalling the above-mentioned
circumstance to the user, while preserving the value in case one switches back
to any digital color format other than YC422.

Warning: this is an untested sketch! I didn't have the leisure to either dig in and fix the zpugcc compile-time errors or set myself up a VM containing older tools :[