### PR TITLE
Only build the Regenerate CSync menu entry for DUAL hardware

### DIFF
--- a/Firmware/README.md
+++ b/Firmware/README.md
@@ -404,16 +404,16 @@ standards-compliant. There is little reason to turn this off, it is here
 mostly for completeness reasons. If this option is off, the X/Y position
 options in the picture menu have no effect.
 
-"Regenerate CSync" is off by default and only relevant for hardware with an
-analog output. It determines if the CSync signal (either discrete or included
-in Y for YPbPr or G for RGsB) is passed through from the console while the
-linedoubler is off or if it is always regenerated from HSync and VSync.
+"Regenerate CSync" is off by default and only available on GCVideo hardware
+with an analog output. It determines if the CSync signal (either discrete or
+included in Y for YPbPr or G for RGsB) is passed through from the console while
+the linedoubler is off or if it is always regenerated from HSync and VSync.
 A regenerated signal does not have serration and equalization pulses, which
 may result in a distortion at the top of the picture. The X/Y position options
-in the picture menu may not have an effect on the analog output of this
+in the picture menu may not have an effect on the analog output if this
 option is set to off.
 
-"Digital color format" is only avaiable if "Enhanced DVI mode" is enabled
+"Digital color format" is only available if "Enhanced DVI mode" is enabled
 in the output settings menu. When it is available, the options are "RGB-F",
 "RGB-L", "YC444" and "YC422". The first two stand for full-range and
 limited-range RGB and have the same effect as the RGB limited range toggle

--- a/Firmware/screen_advanced.c
+++ b/Firmware/screen_advanced.c
@@ -45,8 +45,14 @@ enum {
   MENUITEM_SPOOFINTERLACE,
   MENUITEM_COLORMODE,
   MENUITEM_SAMPLERATEHACK,
-  MENUITEM_EXIT
+  // _EXIT as #define because REGENCSYNC doesn't always exist
 };
+
+#ifdef OUTPUT_DUAL
+#  define MENUITEM_EXIT (MENUITEM_SAMPLERATEHACK + 1)
+#else
+#  define MENUITEM_EXIT (MENUITEM_SAMPLERATEHACK)
+#endif
 
 /* --- valueitems --- */
 
@@ -70,6 +76,7 @@ static valueitem_t value_sampleratehack = { VALTYPE_BOOL, true,
 
 static void advanced_draw(menu_t *menu);
 
+#ifdef OUTPUT_DUAL
 static menuitem_t advanced_items[] = {
   { "Chroma Interpolation", &value_chromainterpol, 1, 0 },
   { "Fix resolution",       &value_reblanking,     2, 0 },
@@ -88,6 +95,25 @@ static menu_t advanced_menu = {
   sizeof(advanced_items) / sizeof(*advanced_items),
   advanced_items
 };
+#else
+static menuitem_t advanced_items[] = {
+  { "Chroma Interpolation", &value_chromainterpol, 1, 0 },
+  { "Fix resolution",       &value_reblanking,     2, 0 },
+  { "Fix sync timing",      &value_resync,         3, 0 },
+  { "Digital color format", &value_colormode,      4, 0 },
+  { "Report 240p as 480i",  &value_spoofinterlace, 5, 0 },
+  { "Sample rate hack",     &value_sampleratehack, 6, 0 },
+  { "Exit",                 NULL,                  8, 0 },
+};
+
+static menu_t advanced_menu = {
+  7, 9,
+  31, 10,
+  advanced_draw,
+  sizeof(advanced_items) / sizeof(*advanced_items),
+  advanced_items
+};
+#endif
 
 static void advanced_draw(menu_t *menu) {
 #ifdef CONSOLE_WII


### PR DESCRIPTION
Proposal:

On GCVideo hardware without an analog video output option, the
"Regenerate CSync" option has no effect, so don't build the menu
entry in the corresponding build configuration, making the menu a
bit more tidy (analogous to Output settings->Analog output).

Warning: this is an untested sketch! I didn't have the leisure to either dig in and fix the zpugcc compile-time errors or set myself up a VM containing older tools :[