### PR TITLE
Disable output when PLL lock is lost

### DIFF
--- a/HDL/gcvideo_dvi/src/datapipe.vhd
+++ b/HDL/gcvideo_dvi/src/datapipe.vhd
@@ -206,7 +206,7 @@ begin
 
   -- logic/bool adapters
   force_ypbpr <= (ForceYPbPr = '0');
-  obuf_oe     <= '1' when video_settings.DisableOutput else '0';
+  obuf_oe     <= clock_locked when video_settings.DisableOutput else '0';
 
   -- cable detect output
   process(video_settings)


### PR DESCRIPTION
Here's why I think this should be necessary:

> so here's an update on the hardware bug on gcvideo adapters, interfering with picoboot among other things:
>
>I think I've identified the root cause
>my HDMI sink (an elgato cam link 4k) pulls up the TMDS lines to something like 1.8V
>now here's the fun part: when the gamecube is powered off, the 3.3V source goes away
>but now that the FPGA has been configured, the output drivers are enabled
>so what happens? the pullups from the sink backpower VDDIO through the output drivers in the FPGA (they are just tiny MOSFETs after all, so they conduct both ways!)
>now since the voltage is high enough, it keeps the 1.2V regulator for the FPGA's core voltage rail fed, and as a result the >FPGA keeps its output drivers active, and you have a vicious cycle
>
>I was able to break this cycle by asserting the reset pin on the FPGA with a screwdriver
>I believe I might be able to cook up a firmware workaround
>
>from what I've been told, this affects all gcvideo clones aside from carby (I don't know what they're doing differently from the others)

The consequence of this issue, aside from the FPGA not resetting properly across power cycles, is that power is being backfed to the GameCube's 3.3V rail in adapters that use it directly. This may be harmful to both the sink and the GameCube, and definitely causes issues with PicoBoot, since the phantom voltage is also enough to keep the RP2040 microcontroller powered, preventing it from resetting across power cycles, therefore failing to perform the bootrom override since it is programmed for one-shot operation at the moment.

The expected result from this change is that disabling the output drivers would stop the pullups from backfeeding VDDIO, allowing everything to power down safely.

This is untested for now, since I don't have a machine with ISE and zpu-gcc set up at the moment.